### PR TITLE
Attemping to produce a local repro for timeout on save

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -582,6 +582,36 @@ impl LoadedVm {
             anyhow::bail!("Servicing is not yet supported for isolated VMs");
         }
 
+        // Start a servicing timeout thread on its own executor in a new thread.
+        // Do this to avoid any tasks that may block the current threadpool
+        // executor, and drop the task when this function returns which will
+        // dismiss the timeout panic.
+        //
+        // This helps catch issues where save may hang, and allows the existing
+        // machinery to send the dump to the host when this process crashes.
+        // Note that we choose to not use a livedump call like the firmware
+        // watchdog handlers, as we expect any hang to be a fatal error for
+        // OpenHCL, whereas the firmware watchdog is a failure inside the guest,
+        // not necessarily inside OpenHCL.
+        let (_servicing_timeout_thread, driver) =
+            pal_async::DefaultPool::spawn_on_thread("servicing-timeout-executor");
+        let _servicing_timeout = driver.clone().spawn("servicing-timeout-task", async move {
+            let mut timer = pal_async::timer::PolledTimer::new(&driver);
+            // Subtract 500ms from the host provided timeout hint to allow for
+            // time for the dump to be sent to the host before termination.
+            // let duration = deadline
+            //     .checked_duration_since(std::time::Instant::now())
+            //     .map(|d| d.saturating_sub(Duration::from_millis(500)))
+            //     .unwrap_or(Duration::from_secs(0));
+            let duration = Duration::from_secs(10); // MATTKUR DO NOT MERGE
+            timer.sleep(duration).await;
+            tracing::error!(
+                CVM_ALLOWED,
+                "servicing operation timed out, triggering panic"
+            );
+            panic!("servicing operation timed out");
+        });
+
         // NOTE: This is set via the corresponding env arg, as this feature is
         // experimental.
         if !capabilities_flags.enable_nvme_keepalive() {

--- a/support/mesh/mesh_channel/src/cell.rs
+++ b/support/mesh/mesh_channel/src/cell.rs
@@ -247,23 +247,6 @@ impl<T: 'static + MeshField + Send + Sync + Clone> Cell<T> {
         })
         .await
     }
-
-    /// Waits for a new value to be set.
-    pub async fn wait_next_with_cx(&mut self, cx: &mut Context<'_>) {
-        poll_fn(|cx| {
-            let mut old_waker = None;
-            let inner = &mut *self.0;
-            inner.port.with_handler(|state| {
-                if inner.last_id == state.id {
-                    old_waker = state.waker.replace(cx.waker().clone());
-                    return Poll::Pending;
-                }
-                inner.last_id = state.id;
-                Poll::Ready(())
-            })
-        })
-        .await
-    }
 }
 
 #[derive(Protobuf)]

--- a/support/mesh/mesh_channel/src/cell.rs
+++ b/support/mesh/mesh_channel/src/cell.rs
@@ -247,6 +247,23 @@ impl<T: 'static + MeshField + Send + Sync + Clone> Cell<T> {
         })
         .await
     }
+
+    /// Waits for a new value to be set.
+    pub async fn wait_next_with_cx(&mut self, cx: &mut Context<'_>) {
+        poll_fn(|cx| {
+            let mut old_waker = None;
+            let inner = &mut *self.0;
+            inner.port.with_handler(|state| {
+                if inner.last_id == state.id {
+                    old_waker = state.waker.replace(cx.waker().clone());
+                    return Poll::Pending;
+                }
+                inner.last_id = state.id;
+                Poll::Ready(())
+            })
+        })
+        .await
+    }
 }
 
 #[derive(Protobuf)]

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -29,6 +29,7 @@ use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
+use pal_async::timer::PolledTimer;
 use parking_lot::RwLock;
 use save_restore::NvmeDriverWorkerSavedState;
 use std::collections::HashMap;

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -24,6 +24,8 @@ use anyhow::Context as _;
 use futures::StreamExt;
 use futures::future::join_all;
 use inspect::Inspect;
+use mesh::Cell;
+use mesh::CellUpdater;
 use mesh::payload::Protobuf;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
@@ -83,6 +85,8 @@ pub struct NvmeDriver<D: DeviceBacking> {
     /// Keeps the controller connected (CC.EN==1) while servicing.
     nvme_keepalive: bool,
     bounce_buffer: bool,
+    #[inspect(with = "|x| x.get()")]
+    attempting_save: Cell<bool>,
 }
 
 /// A container that can hold either a weak or strong reference to a value.
@@ -143,6 +147,8 @@ struct DriverWorkerTask<D: DeviceBacking> {
     #[inspect(skip)]
     recv: mesh::Receiver<NvmeWorkerRequest>,
     bounce_buffer: bool,
+    #[inspect(with = "|x| x.get()")]
+    save_updater: CellUpdater<bool>,
 }
 
 #[derive(Inspect)]
@@ -206,6 +212,7 @@ impl<D: DeviceBacking> IoQueue<D> {
         mem_block: MemoryBlock,
         saved_state: &IoQueueSavedState,
         bounce_buffer: bool,
+        attempting_save: Cell<bool>,
     ) -> anyhow::Result<Self> {
         let IoQueueSavedState {
             cpu,
@@ -220,6 +227,7 @@ impl<D: DeviceBacking> IoQueue<D> {
             queue_data,
             bounce_buffer,
             NoOpAerHandler,
+            attempting_save,
         )?;
 
         Ok(Self {
@@ -326,6 +334,9 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             send,
         });
 
+        let mut save_updater = CellUpdater::new(false);
+        let attempting_save = save_updater.cell();
+
         Ok(Self {
             device_id: device.id().to_owned(),
             task: Some(TaskControl::new(DriverWorkerTask {
@@ -339,6 +350,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                 io_issuers: io_issuers.clone(),
                 recv,
                 bounce_buffer,
+                save_updater,
             })),
             admin: None,
             identify: None,
@@ -348,6 +360,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             namespaces: Default::default(),
             nvme_keepalive: false,
             bounce_buffer,
+            attempting_save,
         })
     }
 
@@ -382,6 +395,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             worker.registers.clone(),
             self.bounce_buffer,
             AdminAerHandler::new(),
+            self.attempting_save.clone(),
         )
         .context("failed to create admin queue pair")?;
 
@@ -766,6 +780,9 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             send,
         });
 
+        let mut save_updater = CellUpdater::new(false);
+        let attempting_save = save_updater.cell();
+
         let mut this = Self {
             device_id: device.id().to_owned(),
             task: Some(TaskControl::new(DriverWorkerTask {
@@ -779,6 +796,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                 io_issuers: io_issuers.clone(),
                 recv,
                 bounce_buffer,
+                save_updater,
             })),
             admin: None, // Updated below.
             identify: Some(Arc::new(
@@ -791,6 +809,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
             namespaces: Default::default(),
             nvme_keepalive: true,
             bounce_buffer,
+            attempting_save: attempting_save.clone(),
         };
 
         let task = &mut this.task.as_mut().unwrap();
@@ -833,6 +852,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     a,
                     bounce_buffer,
                     AdminAerHandler::new(),
+                    attempting_save.clone(),
                 )
                 .expect("failed to restore admin queue pair")
             })
@@ -919,6 +939,7 @@ impl<D: DeviceBacking> NvmeDriver<D> {
                     mem_block,
                     q,
                     bounce_buffer,
+                    attempting_save.clone(),
                 )?;
                 tracing::info!(qid, cpu, ?pci_id, "restoring queue: create issuer");
                 let issuer = IoIssuer {
@@ -1180,6 +1201,7 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             proto.mem,
             &proto.save_state,
             self.bounce_buffer,
+            self.save_updater.cell(),
         )
         .with_context(|| format!("failed to restore io queue for {}, cpu {}", pci_id, cpu))?;
 
@@ -1310,6 +1332,7 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
             self.registers.clone(),
             self.bounce_buffer,
             NoOpAerHandler,
+            self.save_updater.cell(),
         )
         .map_err(|err| DeviceError::IoQueuePairCreationFailure(err, qid))?;
 
@@ -1398,6 +1421,8 @@ impl<D: DeviceBacking> DriverWorkerTask<D> {
         &mut self,
         worker_state: &mut WorkerState,
     ) -> anyhow::Result<NvmeDriverWorkerSavedState> {
+        self.save_updater.set(true).await;
+
         let admin = match self.admin.as_ref() {
             Some(a) => Some(a.save().await?),
             None => None,

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -958,6 +958,11 @@ impl<A: AerHandler> QueueHandler<A> {
                         if let Some(completion) = self.cq.read() {
                             return Event::Completion(completion).into();
                         }
+                        if self.attempting_save.get() {
+                            // If save is being attempted, do not block processing
+                            // on interrupts.
+                            break;
+                        }
                         if interrupt.poll(cx).is_pending() {
                             break;
                         }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -931,6 +931,9 @@ impl<A: AerHandler> QueueHandler<A> {
             let event = if !self.drain_after_restore {
                 // Normal processing of the requests and completions.
                 poll_fn(|cx| {
+                    if self.sq.id() == 1 {
+                        tracing::info!("Looking for space in sq1");
+                    }
                     if !self.sq.is_full() && !self.commands.is_full() {
                         // Prioritize sending AERs to keep the cycle going
                         if self.aer_handler.poll_send_aer() {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
@@ -54,6 +54,9 @@ impl SubmissionQueue {
     }
 
     pub fn is_full(&self) -> bool {
+        if self.sqid == 1 {
+            return true;
+        }
         advance(self.tail, self.len) == self.head
     }
 


### PR DESCRIPTION
The idea here is that once sq reports that it is full, we don't wake it up for Save() events, only for completions ... I think. So our loop in this case might just be going in to a sleeping state and never recovering because activity is halting to a stop. 